### PR TITLE
Add performance:compare_hosts rake task

### DIFF
--- a/app/lib/response_comparator.rb
+++ b/app/lib/response_comparator.rb
@@ -1,0 +1,59 @@
+class ResponseComparator
+  def initialize(path_file:, host_1:, host_2:, output_file:)
+    @path_file = path_file
+    @host_1 = host_1
+    @host_2 = host_2
+    @output_file = output_file
+  end
+
+  def call
+    File.open(@output_file, "w+") do |out|
+      out.write(headers.join("\t"))
+      i = 0
+      IO.foreach(@path_file) do |line|
+        path = line.strip
+        Rails.logger.info "#{i} - #{path}"
+        result = compare(host_1: @host_1, host_2: @host_2, path: path)
+        out.write(result.join("\t") + "\n")
+        i = i + 1
+      end
+    end
+  end
+
+private
+
+  def compare(host_1:, host_2:, path:)
+    response_1 = hit_url(host_1, path)
+    response_2 = hit_url(host_2, path)
+    result_line = results(path:, response_1:, response_2:)
+  end
+
+  def hit_url(host, path)
+    t = Time.now
+    response = Net::HTTP.get_response(host, "/api/content" + path)
+    body_size = response.body.strip.length
+    time = Time.now - t
+    { 
+      status: response.code,
+      body_size: ,
+      time: ,
+    }
+  end
+
+  def headers
+    ["url", "host-1-status", "host-1-body-size", "host-1-response-time", "host-2-status", "host-2-body-size", "host-2-response-time"]
+  end
+  
+  def results(path:, response_1:, response_2:)
+    [
+      path,
+      response_1[:status],
+      response_1[:body_size],
+      response_1[:time],
+      response_2[:status],
+      response_2[:body_size],
+      response_2[:time],
+    ]
+  end
+  
+end

--- a/lib/tasks/performance.rake
+++ b/lib/tasks/performance.rake
@@ -1,0 +1,14 @@
+namespace :performance do
+  desc "
+    Compare response sizes and times from two hosts,
+    using a given file of request paths, one path per line
+  "
+  task :compare_hosts, %i[path_file host_1 host_2 output_file] => :environment do |_t, args|
+    ResponseComparator.new(
+      path_file: args[:path_file],
+      host_1: args[:host_1],
+      host_2: args[:host_2],
+      output_file: args[:output_file]
+    ).call
+  end
+end


### PR DESCRIPTION
Add a rake task and class in lib to encapsulate the code I've been running for side-by-side performance comparisons of the MongoDB and PostgreSQL apps

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
