### PR TITLE
Add upstream warning to pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,10 @@
+# Be Very Careful With Pull Requests
+
+This is a forked repo, so by default Github will think you want to make a PR against
+the pupstream content-store repo](https://github.com/alphagov/content-store).
+When raising a PR, *you must manually change the 'merge into ...' repository to be
+this repo!* 
+
 This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   
 
 ⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 # Be Very Careful With Pull Requests
 
 This is a forked repo, so by default Github will think you want to make a PR against
-the pupstream content-store repo](https://github.com/alphagov/content-store).
-When raising a PR, *you must manually change the 'merge into ...' repository to be
+the upstream/base content-store repo](https://github.com/alphagov/content-store).
+When raising a PR, *you _must_ manually change the base repository to
 this repo!* 
 
 This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   


### PR DESCRIPTION
This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
